### PR TITLE
Fix for forget bug

### DIFF
--- a/pryzm/__init__.py
+++ b/pryzm/__init__.py
@@ -1,4 +1,4 @@
 name = "pryzm"
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 from pryzm.codes import text_attributes
 from pryzm.pryzm import Pryzm

--- a/pryzm/pryzm.py
+++ b/pryzm/pryzm.py
@@ -9,7 +9,7 @@ class Pryzm(object):
     with an ascii escape color seqence 31 to provide color.
     """
     _text_attributes = text_attributes
-    def __init__(self, *text, echo=False):
+    def __init__(self, *text, echo=False, fixed=False):
         """Creates the base object to generate functions.
         *text        any number of text fields.  They will be wrapped end to end, not around each token
         echo         If this is true, a generated function will act like python's print.
@@ -23,6 +23,7 @@ class Pryzm(object):
         self.ASC = u"\u001b["
         self.CLR = u"\u001b[0m"
         self.echo = echo
+        self.fixed = fixed 
 
         for feature, ansi_code in self._text_attributes.items():
             self._add_color(feature, ansi_code)
@@ -40,15 +41,17 @@ class Pryzm(object):
         """
         def fn(self, *text):
             text = " ".join([str(word) for word in text])
-            self.features.append(str(ansi_code))
+            if str(ansi_code) not in self.features:
+                self.features.append(str(ansi_code))
 
             if text:
                 self.text = text
-                saved_return = self.show()
+                saved_return = u"{}{}m{}{}".format(self.ASC, ";".join(self.features), self.text, self.CLR)
                 if self.echo:
-                    print(self.show())
+                    print(saved_return)
 
-                self.reset()
+                if not self.fixed:
+                    self.reset()
                 return saved_return
             else:                          # If no text, return self so we can chain on '.'
                 return self

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pryzm",
-    version="0.1.3",
+    version="0.1.4",
     author="Efrain Olivares",
     author_email="efrain.olivares@gmail.com",
     description="Basic support for asci color text on linux terminals",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,6 +10,7 @@ def test_basic_foreground():
 
     assert pz.red("test")    == '\x1b[31mtest\x1b[0m'
     assert pz.cyan("test")   == '\x1b[36mtest\x1b[0m'
+    assert pz.blue("test")   == '\x1b[34mtest\x1b[0m'
 
 def test_basic_background():
     pz = pryzm.Pryzm()
@@ -52,3 +53,15 @@ def test_convert_to_string():
 
     assert pz.blue("This is", 1, "also blue") == '\x1b[34mThis is 1 also blue\x1b[0m'
     assert pz.blue("This is", {'key': 'val'}, "also blue") == '\x1b[34mThis is {\'key\': \'val\'} also blue\x1b[0m'
+
+def test_second_use():
+    pz = pryzm.Pryzm(echo=False, fixed=True)
+    blue_bold = pz.blue()._bold
+
+    assert blue_bold("Hello1") == '\x1b[34;1mHello1\x1b[0m'
+    blue_bold("whatevs")
+    blue_bold("this")
+    blue_bold("that")
+    blue_bold("and the other")
+
+    assert blue_bold("Hello2") == '\x1b[34;1mHello2\x1b[0m'


### PR DESCRIPTION
version 1.4

If you set up a two feature function like blue()._bold, it would work the first time, but the second time forward it would 'forget' the blue()...

Added flag to skip the reset which is what was causing the problem